### PR TITLE
Add animated theme toggle and modern transitions

### DIFF
--- a/my-app/src/components/Layout.jsx
+++ b/my-app/src/components/Layout.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, Container, Flex, Button, useColorMode, useColorModeValue, IconButton } from '@chakra-ui/react';
+import { motion } from 'framer-motion';
 import { Link as ScrollLink } from 'react-scroll';
 import { MoonIcon, SunIcon } from '@chakra-ui/icons';
 
@@ -16,18 +17,25 @@ export default function Layout({ children }) {
     { name: "Contact", to: "contact" }
   ];
 
+  const MotionBox = motion(Box);
+  const MotionButton = motion(Button);
+  const MotionIconButton = motion(IconButton);
+
   return (
-    <Box bg={bgColor} color={textColor} minH="100vh">
-      <Box 
-        as="header" 
-        position="fixed" 
-        width="full" 
-        zIndex="banner" 
-        bg={headerBgColor} 
+    <MotionBox bg={bgColor} color={textColor} minH="100vh" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.6 }}>
+      <MotionBox
+        as="header"
+        position="fixed"
+        width="full"
+        zIndex="banner"
+        bg={headerBgColor}
         className="alternating-diagonal-lines"
         boxShadow="sm"
         h="70px"
         overflow="hidden"
+        initial={{ y: -80 }}
+        animate={{ y: 0 }}
+        transition={{ duration: 0.5 }}
       >
         <Container maxW="container.xl" h="full" px={{ base: 2, sm: 4 }}>
           <Flex as="nav" h="full" justify="space-between" align="center" wrap="wrap">
@@ -41,32 +49,38 @@ export default function Layout({ children }) {
                   offset={-70}
                   duration={50}
                 >
-                  <Button
+                  <MotionButton
                     variant="ghost"
                     mr={3}
                     mb={{ base: 2, md: 0 }}
                     onClick={() => {}}
                     zIndex={2}
                     fontSize={{ base: "sm", sm: "md" }}
+                    whileHover={{ scale: 1.1 }}
+                    whileTap={{ scale: 0.95 }}
                   >
                     {item.name}
-                  </Button>
+                  </MotionButton>
                 </ScrollLink>
               ))}
             </Flex>
-            <IconButton
+            <MotionIconButton
               icon={colorMode === 'light' ? <MoonIcon /> : <SunIcon />}
               onClick={toggleColorMode}
               variant="ghost"
               aria-label="Toggle color mode"
               zIndex={2}
+              animate={{ rotate: colorMode === 'light' ? 0 : 180 }}
+              whileHover={{ scale: 1.2 }}
+              whileTap={{ scale: 0.9 }}
+              transition={{ duration: 0.5 }}
             />
           </Flex>
         </Container>
-      </Box>
+      </MotionBox>
       <Box as="main" pt="70px">
         {children}
       </Box>
-    </Box>
+    </MotionBox>
   );
 }

--- a/my-app/src/pages/Home.jsx
+++ b/my-app/src/pages/Home.jsx
@@ -32,11 +32,23 @@ import ProjectSlideshow from './ProjectSlideshow';
 
 const Model = lazy(() => import('./Model'));
 
+const MotionBox = motion(Box);
+
 const ProjectCard = ({ project }) => {
   const cardBg = useColorModeValue("white", "gray.700");
 
   return (
-    <Box borderWidth="1px" borderRadius="lg" overflow="hidden" boxShadow="xl" bg={cardBg}>
+    <MotionBox
+      borderWidth="1px"
+      borderRadius="lg"
+      overflow="hidden"
+      boxShadow="xl"
+      bg={cardBg}
+      initial={{ opacity: 0, y: 30 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.5 }}
+    >
       <Flex direction={{ base: 'column', lg: 'row' }} alignItems="center">
         <Box flex="1" p={6}>
           <Heading as="h3" size="lg" mb={4}>{project.title}</Heading>
@@ -63,7 +75,7 @@ const ProjectCard = ({ project }) => {
           <ProjectSlideshow project={project} />
         </Box>
       </Flex>
-    </Box>
+    </MotionBox>
   );
 };
 
@@ -71,7 +83,18 @@ const ExperienceCard = ({ experience }) => {
   const cardBg = useColorModeValue("white", "gray.700");
 
   return (
-    <Box borderWidth="1px" borderRadius="lg" overflow="hidden" boxShadow="md" p={6} bg={cardBg}>
+    <MotionBox
+      borderWidth="1px"
+      borderRadius="lg"
+      overflow="hidden"
+      boxShadow="md"
+      p={6}
+      bg={cardBg}
+      initial={{ opacity: 0, y: 30 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.5 }}
+    >
       <Heading as="h3" size="lg" mb={2}>{experience.title}</Heading>
       <Text fontWeight="bold" mb={2}>{experience.company}</Text>
       <Text mb={2}>{experience.duration}</Text>
@@ -83,7 +106,7 @@ const ExperienceCard = ({ experience }) => {
           </WrapItem>
         ))}
       </Wrap>
-    </Box>
+    </MotionBox>
   );
 };
 

--- a/my-app/src/styles/custom.css
+++ b/my-app/src/styles/custom.css
@@ -1,5 +1,13 @@
 /* src/styles/custom.css */
-:root {
+body {
+    transition: background-color 0.6s ease, color 0.6s ease;
+  }
+
+  body * {
+    transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+  }
+
+  :root {
     --color-background: #121212;
     --color-surface: #1e1e1e;
     --color-primary: #007aff;


### PR DESCRIPTION
## Summary
- Smooth color-mode transitions with global CSS
- Animate layout header, navigation, and theme toggle using framer-motion
- Motion-based project and experience cards for a modern feel

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b85b475e4c832d9d40c6f1c63ec29e