### PR TITLE
Revamp UI: Dark lilac theme + modern layout (Chakra)

### DIFF
--- a/my-app/src/components/Layout.jsx
+++ b/my-app/src/components/Layout.jsx
@@ -49,6 +49,7 @@ export default function Layout({ children }) {
                 >
                   <MotionButton
                     variant="ghost"
+                    colorScheme="lilac"
                     mr={3}
                     mb={{ base: 2, md: 0 }}
                     onClick={() => {}}
@@ -67,6 +68,7 @@ export default function Layout({ children }) {
               icon={colorMode === 'light' ? <MoonIcon /> : <SunIcon />}
               onClick={toggleColorMode}
               variant="ghost"
+              colorScheme="lilac"
               aria-label="Toggle color mode"
               zIndex={2}
               animate={{ rotate: colorMode === 'light' ? 0 : 180 }}

--- a/my-app/src/components/Layout.jsx
+++ b/my-app/src/components/Layout.jsx
@@ -1,14 +1,11 @@
 import React from 'react';
-import { Box, Container, Flex, Button, useColorMode, useColorModeValue, IconButton } from '@chakra-ui/react';
+import { Box, Container, Flex, Button, useColorMode, IconButton } from '@chakra-ui/react';
 import { motion } from 'framer-motion';
 import { Link as ScrollLink } from 'react-scroll';
 import { MoonIcon, SunIcon } from '@chakra-ui/icons';
 
 export default function Layout({ children }) {
   const { colorMode, toggleColorMode } = useColorMode();
-  const bgColor = useColorModeValue("white", "gray.800");
-  const textColor = useColorModeValue("gray.800", "white");
-  const headerBgColor = useColorModeValue("blue.50", "gray.900");
 
   const navItems = [
     { name: "Home", to: "home" },
@@ -22,13 +19,14 @@ export default function Layout({ children }) {
   const MotionIconButton = motion(IconButton);
 
   return (
-    <MotionBox bg={bgColor} color={textColor} minH="100vh" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.6 }}>
+    <MotionBox bg="bg.canvas" color="text.primary" minH="100vh" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.6 }}>
       <MotionBox
         as="header"
-        position="fixed"
+        position="sticky"
+        top="0"
         width="full"
         zIndex="banner"
-        bg={headerBgColor}
+        bg="bg.surface"
         className="alternating-diagonal-lines"
         boxShadow="sm"
         h="70px"
@@ -55,7 +53,8 @@ export default function Layout({ children }) {
                     mb={{ base: 2, md: 0 }}
                     onClick={() => {}}
                     zIndex={2}
-                    fontSize={{ base: "sm", sm: "md" }}
+                    fontSize={{ base: 'sm', sm: 'md' }}
+                    _hover={{ bg: 'surface.700' }}
                     whileHover={{ scale: 1.1 }}
                     whileTap={{ scale: 0.95 }}
                   >

--- a/my-app/src/pages/Home.jsx
+++ b/my-app/src/pages/Home.jsx
@@ -63,11 +63,11 @@ const ProjectCard = ({ project }) => {
           <Wrap spacing={2} mb={4}>
             {project.tags.map((tag, index) => (
               <WrapItem key={index}>
-                <Tag colorScheme="blue">{tag}</Tag>
+                <Tag colorScheme="lilac">{tag}</Tag>
               </WrapItem>
             ))}
           </Wrap>
-          <Button as="a" href={project.projectUrl} target="_blank" colorScheme="blue">
+          <Button as="a" href={project.projectUrl} target="_blank" colorScheme="lilac">
             Visit Project
           </Button>
         </Box>
@@ -102,7 +102,7 @@ const ExperienceCard = ({ experience }) => {
       <Wrap spacing={2}>
         {experience.skills.map((skill, index) => (
           <WrapItem key={index}>
-            <Tag colorScheme="green">{skill}</Tag>
+            <Tag colorScheme="lilac">{skill}</Tag>
           </WrapItem>
         ))}
       </Wrap>
@@ -112,11 +112,11 @@ const ExperienceCard = ({ experience }) => {
 
 const Home = () => {
   const bgGradient = useColorModeValue(
-    'linear(to-r, lilac.500, accent.600)',
-    'linear(to-r, lilac.400, accent.500)'
+    'linear(to-r, lilac.500, lilac.600)',
+    'linear(to-r, lilac.400, lilac.500)'
   );
   const cardBg = useColorModeValue('white', 'bg.surface');
-  const spinnerColor = useColorModeValue('accent.600', 'lilac.300');
+  const spinnerColor = useColorModeValue('lilac.600', 'lilac.300');
 
   const projects = [
     {
@@ -192,7 +192,7 @@ const Home = () => {
                 <Text fontSize="lg" color="gray.500">
                   Explore my projects and discover how I'm shaping the digital world, one line of code at a time.
                 </Text>
-                <Button as={Link} href="#projects" size="lg" colorScheme="blue" mt={4}>
+                <Button as={Link} href="#projects" size="lg" colorScheme="lilac" mt={4}>
                   View My Projects
                 </Button>
               </VStack>
@@ -273,8 +273,8 @@ const Home = () => {
               </Heading>
               <Tabs isFitted variant="enclosed">
                 <TabList mb="1em">
-                  <Tab _selected={{ color: "white", bg: "blue.500" }}>Projects</Tab>
-                  <Tab _selected={{ color: "white", bg: "blue.500" }}>Experience</Tab>
+                  <Tab _selected={{ color: "white", bg: "lilac.500" }}>Projects</Tab>
+                  <Tab _selected={{ color: "white", bg: "lilac.500" }}>Experience</Tab>
                 </TabList>
                 <TabPanels>
                   <TabPanel>
@@ -316,15 +316,15 @@ const Home = () => {
               <HStack spacing={10} align="flex-start" flexWrap="wrap">
                 <VStack  flex="1" align="stretch" spacing={6} minW="300px">
                   <HStack>
-                    <Icon as={FaEnvelope} w={6} h={6} color="blue.500" />
+                    <Icon as={FaEnvelope} w={6} h={6} color="lilac.500" />
                     <Link href="mailto:shreyas.yerabati@gmail.com">shreyas.yerabati@gmail.com</Link>
                   </HStack>
                   <HStack>
-                    <Icon as={FaLinkedin} w={6} h={6} color="blue.500" />
+                    <Icon as={FaLinkedin} w={6} h={6} color="lilac.500" />
                     <Link href="https://www.linkedin.com/in/shreyas-yerabati-1a74a0294/" isExternal>LinkedIn Profile</Link>
                   </HStack>
                   <HStack>
-                    <Icon as={FaGithub} w={6} h={6} color="blue.500" />
+                    <Icon as={FaGithub} w={6} h={6} color="lilac.500" />
                     <Link href="https://github.com/sryerabati" isExternal>GitHub  Profile</Link>
                   </HStack>
                 </VStack>

--- a/my-app/src/pages/Home.jsx
+++ b/my-app/src/pages/Home.jsx
@@ -35,7 +35,7 @@ const Model = lazy(() => import('./Model'));
 const MotionBox = motion(Box);
 
 const ProjectCard = ({ project }) => {
-  const cardBg = useColorModeValue("white", "gray.700");
+  const cardBg = useColorModeValue('white', 'bg.surface');
 
   return (
     <MotionBox
@@ -80,7 +80,7 @@ const ProjectCard = ({ project }) => {
 };
 
 const ExperienceCard = ({ experience }) => {
-  const cardBg = useColorModeValue("white", "gray.700");
+  const cardBg = useColorModeValue('white', 'bg.surface');
 
   return (
     <MotionBox
@@ -111,9 +111,12 @@ const ExperienceCard = ({ experience }) => {
 };
 
 const Home = () => {
-  const bgGradient = useColorModeValue("linear(to-r, blue.400, teal.500)", "linear(to-r, blue.600, teal.700)");
-  const cardBg = useColorModeValue("white", "gray.700");
-  const spinnerColor = useColorModeValue("blue.500", "blue.200");
+  const bgGradient = useColorModeValue(
+    'linear(to-r, lilac.500, accent.600)',
+    'linear(to-r, lilac.400, accent.500)'
+  );
+  const cardBg = useColorModeValue('white', 'bg.surface');
+  const spinnerColor = useColorModeValue('accent.600', 'lilac.300');
 
   const projects = [
     {
@@ -213,7 +216,7 @@ const Home = () => {
       </Box>
 
       {/* About Section */}
-      <Box id="about" bg={useColorModeValue("gray.50", "gray.900")} py={20}>
+      <Box id="about" bg={useColorModeValue('white', 'bg.surface')} py={20}>
         <Container maxW="container.xl">
           <motion.div
             initial={{ opacity: 0, y: 50 }}
@@ -296,7 +299,7 @@ const Home = () => {
       </Box>
 
       {/* Contact Section */}
-      <Box id="contact" bg={useColorModeValue("gray.50", "gray.900")} py={20}>
+      <Box id="contact" bg={useColorModeValue('white', 'bg.surface')} py={20}>
         <Container maxW="container.xl">
           <motion.div
             initial={{ opacity: 0, y: 50 }}

--- a/my-app/src/pages/Model.jsx
+++ b/my-app/src/pages/Model.jsx
@@ -9,8 +9,8 @@ export default function Model() {
   const modelRef = useRef();
   const { colorMode } = useColorMode();
   
-  // Use a lighter blue in dark mode and a darker blue in light mode
-  const dotColor = useColorModeValue('#1992d4', '#81defd');
+  // Use a lighter purple in dark mode and a darker purple in light mode
+  const dotColor = useColorModeValue('#9C7DD1', '#B997F5');
 
   useEffect(() => {
     const dotShader = {

--- a/my-app/src/pages/ProjectSlideshow.jsx
+++ b/my-app/src/pages/ProjectSlideshow.jsx
@@ -181,13 +181,13 @@ export default function ProjectSlideshow({ project }) {
         justifyContent="space-between"
       >
         <Flex alignItems="center">
-          <Box as="button" w="12px" h="12px" borderRadius="full" bg="red.500" mr={2} />
+          <Box as="button" w="12px" h="12px" borderRadius="full" bg="lilac.500" mr={2} />
           <Box
             as="button"
             w="12px"
             h="12px"
             borderRadius="full"
-            bg="yellow.500"
+            bg="lilac.500"
             mr={2}
             position="relative"
             onClick={toggleExpand}
@@ -196,7 +196,7 @@ export default function ProjectSlideshow({ project }) {
           >
             <Icon
               as={FaMinus}
-              color="yellow.700"
+              color="lilac.600"
               position="absolute"
               top="50%"
               left="50%"
@@ -213,14 +213,14 @@ export default function ProjectSlideshow({ project }) {
             w="12px"
             h="12px"
             borderRadius="full"
-            bg="green.500"
+            bg="lilac.500"
             position="relative"
             onClick={toggleFullscreen}
             _hover={{ '& > .fullscreen-icon': { opacity: 1 } }}
           >
             <Icon
               as={isFullscreen ? FaCompress : FaExpand}
-              color="green.700"
+              color="lilac.600"
               position="absolute"
               top="50%"
               left="50%"
@@ -237,10 +237,10 @@ export default function ProjectSlideshow({ project }) {
           {project.title} Gallery
         </Text>
         <Flex>
-          <Button onClick={prevImage} size="xs" variant="ghost" mr={2}>
+          <Button onClick={prevImage} size="xs" variant="ghost" colorScheme="lilac" mr={2}>
             <Icon as={FiArrowLeft} />
           </Button>
-          <Button onClick={nextImage} size="xs" variant="ghost">
+          <Button onClick={nextImage} size="xs" variant="ghost" colorScheme="lilac">
             <Icon as={FiArrowRight} />
           </Button>
         </Flex>
@@ -302,7 +302,7 @@ export default function ProjectSlideshow({ project }) {
               h={3}
               mx={1}
               borderRadius="50%"
-              bg={index === currentImageIndex ? 'blue.500' : 'gray.400'}
+              bg={index === currentImageIndex ? 'lilac.500' : 'gray.400'}
               cursor="pointer"
               onClick={() => {
                 setDirection(index > currentImageIndex ? 1 : -1);

--- a/my-app/src/theme.js
+++ b/my-app/src/theme.js
@@ -5,22 +5,81 @@ const config = {
   useSystemColorMode: false,
 };
 
-const theme = extendTheme({
-  config,
+const colors = {
+  bg: {
+    950: '#0E0B14',
+    900: '#131021',
+  },
+  surface: {
+    800: '#1C1730',
+    700: '#241C3F',
+  },
+  lilac: {
+    300: '#D9C7FF',
+    400: '#C9B8F0',
+    500: '#B997F5',
+    600: '#9C7DD1',
+  },
+  accent: {
+    500: '#A78BFA',
+    600: '#8B5CF6',
+  },
+};
+
+const semanticTokens = {
   colors: {
-    brand: {
-      50: '#e3f8ff',
-      100: '#b3ecff',
-      200: '#81defd',
-      300: '#5ed0fa',
-      400: '#40c3f7',
-      500: '#2bb0ed',
-      600: '#1992d4',
-      700: '#127fbf',
-      800: '#0b69a3',
-      900: '#035388',
+    'bg.canvas': { default: 'white', _dark: 'bg.900' },
+    'bg.surface': { default: 'white', _dark: 'surface.800' },
+    'text.primary': { default: 'gray.800', _dark: 'gray.100' },
+    'text.muted': { default: 'gray.600', _dark: 'gray.300' },
+    brand: { default: 'lilac.600', _dark: 'lilac.500' },
+  },
+};
+
+const fonts = {
+  heading: `'Inter', system-ui, sans-serif`,
+  body: `'Inter', system-ui, sans-serif`,
+};
+
+const lineHeights = {
+  heading: 1.15,
+  body: 1.6,
+};
+
+const radii = {
+  xl: '20px',
+  '2xl': '24px',
+};
+
+const styles = {
+  global: {
+    'html, body': {
+      bg: 'bg.canvas',
+      color: 'text.primary',
+    },
+    '*:focus-visible': {
+      outline: '2px solid',
+      outlineColor: 'accent.600',
+      outlineOffset: '2px',
     },
   },
+};
+
+const transitions = {
+  duration: {
+    normal: '200ms',
+  },
+};
+
+const theme = extendTheme({
+  config,
+  colors,
+  semanticTokens,
+  fonts,
+  lineHeights,
+  radii,
+  styles,
+  transition: transitions,
 });
 
 export default theme;

--- a/my-app/src/theme.js
+++ b/my-app/src/theme.js
@@ -20,10 +20,6 @@ const colors = {
     500: '#B997F5',
     600: '#9C7DD1',
   },
-  accent: {
-    500: '#A78BFA',
-    600: '#8B5CF6',
-  },
 };
 
 const semanticTokens = {
@@ -59,7 +55,7 @@ const styles = {
     },
     '*:focus-visible': {
       outline: '2px solid',
-      outlineColor: 'accent.600',
+      outlineColor: 'lilac.600',
       outlineOffset: '2px',
     },
   },


### PR DESCRIPTION
## Summary
- introduce lilac-focused dark theme with semantic tokens and global focus ring
- modernize layout/header and swap project/section cards to theme colors
- adjust content sections to use brand gradients

## Testing
- `npx eslint .`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9ae5c256c832db35a94386ab80bea